### PR TITLE
Feat/support validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,13 @@ Install package using yarn
 
 ## Usage
 
+    import React from 'react'
     import { Form, useForm, FormContext } from '@ballatech/formz'
 
+    const validator = (value, fields) => value.length < 5 ? 'Too short' : null
+
     const Component = () => {
-      const { value, setField } = useForm('username', '')
+      const { value, setField } = useForm('username', '', validator)
 
       return (
         <input
@@ -32,10 +35,16 @@ Install package using yarn
       return <button onClick={reset}>Reset</button>
     }
 
+    const Submit = () => {
+      const { isValid } = React.useContext(FormContext)
+
+      return <button disabled={!isValid} type="submit">Submit</button>
+    }
+
     const MyCoolForm = ({ onSubmit }) => (
       <Form onSubmit={onSubmit}>
         <Component />
-        <button type="submit">Submit</button>
+        <Submit>
         <Reset />
       </Form>
      )

--- a/src/Form.js
+++ b/src/Form.js
@@ -19,7 +19,7 @@ type State = {
   [string]: Field,
 }
 
-export type Validator = (value: any) => string | null | void
+export type Validator = (value: any, fields: State) => string | null | void
 
 export type Context = {|
   +fields: State,
@@ -55,7 +55,23 @@ const Form = ({ children, onSubmit = () => {} }: Props) => {
     setState(
       (s: State): State => ({
         ...s,
-        [key]: { value, validate, error: typeof validate === 'function' ? validate(value) : null },
+        [key]: {
+          value,
+          validate,
+          error:
+            typeof validate === 'function'
+              ? validate(value, {
+                  ...Object.keys(s).reduce(
+                    (acc, fieldName) => ({
+                      ...acc,
+                      [fieldName]: s[fieldName].value,
+                    }),
+                    {}
+                  ),
+                  [key]: value,
+                })
+              : null,
+        },
       })
     )
   }

--- a/src/Form.js
+++ b/src/Form.js
@@ -9,22 +9,25 @@ export type Props = {
   +onSubmit?: ({ [string]: any }) => void,
 }
 
-type Field = {
+type Field = {|
   value: string,
-  error?: string,
+  error: ?string,
   warn?: string,
-}
+|}
 
 type State = {
   [string]: Field,
 }
 
-export type Context = {
+export type Validator = (value: any) => string | null | void
+
+export type Context = {|
   +fields: State,
-  +setField: string => any => void,
+  +isValid: boolean,
+  +setField: (name: string, validate?: Validator) => any => void,
   +submit: () => void,
   +reset: () => void,
-}
+|}
 
 // ===========================
 // Context
@@ -33,6 +36,7 @@ export type Context = {
 export const FormContext = React.createContext<Context>(
   ({
     fields: {},
+    isValid: true,
     setField: () => () => {},
     submit: () => {},
     reset: () => {},
@@ -44,8 +48,16 @@ export const FormContext = React.createContext<Context>(
 // ===========================
 const Form = ({ children, onSubmit = () => {} }: Props) => {
   const [state, setState] = React.useState<State>({})
-  const setField = (key: string) => (value: any) => {
-    setState((s: State): State => ({ ...s, [key]: { value } }))
+  const isValid = Object.keys(state)
+    .map(field => state[field].error)
+    .every(error => !error)
+  const setField = (key: string, validate?: Validator) => (value: any) => {
+    setState(
+      (s: State): State => ({
+        ...s,
+        [key]: { value, validate, error: typeof validate === 'function' ? validate(value) : null },
+      })
+    )
   }
   const reset = () => setState({})
   const submit = () =>
@@ -62,7 +74,7 @@ const Form = ({ children, onSubmit = () => {} }: Props) => {
     event.preventDefault()
     submit()
   }
-  const context = { fields: state, setField, submit, reset }
+  const context = { fields: state, isValid, setField, submit, reset }
 
   return (
     <FormContext.Provider value={context}>

--- a/src/Form.js
+++ b/src/Form.js
@@ -19,7 +19,7 @@ type State = {
   [string]: Field,
 }
 
-export type Validator = (value: any, fields: State) => string | null | void
+export type Validator = (value: any, fields: { [string]: any }) => string | null | void
 
 export type Context = {|
   +fields: State,

--- a/src/useForm.js
+++ b/src/useForm.js
@@ -1,20 +1,24 @@
 // @flow
 import React from 'react'
 import { FormContext } from './Form'
+import type { Validator } from './Form'
 
-const useForm = (name: string, defaultValue: any = '') => {
-  const { fields, setField, submit, reset } = React.useContext(FormContext)
+const useForm = (name: string, defaultValue: any = '', validate?: Validator) => {
+  const { fields, isValid, setField, submit, reset } = React.useContext(FormContext)
   const value = fields[name] && fields[name].value
+  const error = fields[name] && fields[name].error
   const isFirstRender = typeof value === 'undefined'
 
   React.useEffect(() => {
     if (isFirstRender) {
-      setField(name)(defaultValue)
+      setField(name, validate)(defaultValue)
     }
   })
   return {
     value: isFirstRender ? defaultValue : value,
-    setField: setField(name),
+    error: isFirstRender ? null : error,
+    setField: setField(name, validate),
+    isValid,
     submit,
     reset,
   }

--- a/tests/Form.spec.js
+++ b/tests/Form.spec.js
@@ -38,6 +38,15 @@ describe('Form', () => {
     expect(context.fields).toEqual({})
   })
 
+  test('should expose the isValid on the context', () => {
+    mount(
+      <Form>
+        <ContextChecker />
+      </Form>
+    )
+    expect(context.isValid).toEqual(true)
+  })
+
   test('should expose setField() on the context', () => {
     mount(
       <Form>
@@ -51,13 +60,13 @@ describe('Form', () => {
       context.setField('foo')('bar')
     })
 
-    expect(context.fields).toEqual({ foo: { value: 'bar' } })
+    expect(context.fields.foo.value).toEqual('bar')
 
     act(() => {
       context.setField('foo')('baz')
     })
 
-    expect(context.fields).toEqual({ foo: { value: 'baz' } })
+    expect(context.fields.foo.value).toEqual('baz')
   })
 
   test('should expose submit() on the context', () => {

--- a/tests/useForm.spec.js
+++ b/tests/useForm.spec.js
@@ -67,10 +67,14 @@ describe('useForm', () => {
   })
 
   test('should support validation on the field', () => {
-    const minLength = value => (value.length < 10 ? 'too short' : null)
+    const validators = {
+      minLength: value => (value.length < 10 ? 'too short' : null),
+    }
+    const validatorSpy = jest.spyOn(validators, 'minLength')
+
     const wrapper = mount(
       <Form>
-        <SampleInputComponent name="foo" validate={minLength} />
+        <SampleInputComponent name="foo" validate={validators.minLength} />
         <ContextChecker />
       </Form>
     )
@@ -78,6 +82,7 @@ describe('useForm', () => {
     expect(context.fields.foo.value).toEqual('')
     expect(context.fields.foo.error).toEqual('too short')
     expect(context.isValid).toEqual(false)
+    expect(validatorSpy).toHaveBeenCalledWith('', { foo: '' })
 
     act(() => {
       inputFoo.simulate('change', { target: { value: 'short' } })
@@ -86,6 +91,7 @@ describe('useForm', () => {
 
     expect(context.fields.foo.value).toEqual('short')
     expect(context.fields.foo.error).toEqual('too short')
+    expect(validatorSpy).toHaveBeenCalledWith('short', { foo: 'short' })
 
     act(() => {
       inputFoo.simulate('change', { target: { value: 'longEnoughValue' } })
@@ -94,6 +100,7 @@ describe('useForm', () => {
 
     expect(context.fields.foo.value).toEqual('longEnoughValue')
     expect(context.fields.foo.error).toEqual(null)
+    expect(validatorSpy).toHaveBeenCalledWith('longEnoughValue', { foo: 'longEnoughValue' })
     expect(context.isValid).toEqual(true)
   })
 })


### PR DESCRIPTION
### Initial implementation of field validation

1. useForm() now accepts a third parameter an optional field validator function with the following signature: `(value: any, fields: { [string]: any }) => string | null | void`

2. isValid is exposed as part of the FormContext